### PR TITLE
fix: size of observation space

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ceia-soccer-twos
-version = 0.0.25
+version = 0.1.2
 author = Bryan L M Oliveira @ CExIA
 author_email = bryanlmoliveira@gmail.com
 description = A pre-compiled soccer-twos (Unity ML Agents) environment with a nice visualizer.


### PR DESCRIPTION
Esse PR é uma sugestão para alteração do shape retornado pelo env.observation_space.shape[0] para mostrar os 336 valores (ao invés dos 345 retornados pelo game).

Ponto de atenção:
Verificar alteração na linha 161:
-np.inf, np.inf, dtype=np.float32, shape=(self._get_vec_obs_size(),)  --->  -np.inf, np.inf, dtype=np.float32, shape=((OBSERVATION_SECTIONS["OBS_SIZE"],))

close #1 